### PR TITLE
tools: Rename IPC functions to reduce misleading

### DIFF
--- a/src/tools/ipc.c
+++ b/src/tools/ipc.c
@@ -459,7 +459,7 @@ static int userspace_fetch_conf(struct wgdevice **out, const char *interface)
 	ret = -EPROTO;
 err:
 	free(key);
-	free_wgdevice(conf);
+	free_conf(conf);
 	*out = NULL;
 	fclose(f);
 	errno = -ret;
@@ -932,7 +932,7 @@ try_again:
 
 	nlg = mnlg_socket_open(WG_GENL_NAME, WG_GENL_VERSION);
 	if (!nlg) {
-		free_wgdevice(*conf);
+		free_conf(*conf);
 		*conf = NULL;
 		return -errno;
 	}
@@ -955,7 +955,7 @@ out:
 		mnlg_socket_close(nlg);
 	}
 	if (ret) {
-		free_wgdevice(*conf);
+		free_conf(*conf);
 		if (ret == -EINTR) {
 			goto try_again;
 		}
@@ -1017,4 +1017,9 @@ int ipc_set_device(const struct wgdevice *newconf)
 #else
 	return userspace_set_device(newconf);
 #endif
+}
+
+void free_conf(struct wgdevice *conf)
+{
+	free_wgdevice(conf);
 }

--- a/src/tools/ipc.h
+++ b/src/tools/ipc.h
@@ -10,8 +10,8 @@
 
 struct wgdevice;
 
-int ipc_set_device(struct wgdevice *dev);
-int ipc_get_device(struct wgdevice **dev, const char *interface);
+int ipc_set_device(const struct wgdevice *conf);
+int ipc_fetch_conf(struct wgdevice **conf, const char *interface);
 char *ipc_list_devices(void);
 
 #endif

--- a/src/tools/ipc.h
+++ b/src/tools/ipc.h
@@ -11,7 +11,30 @@
 struct wgdevice;
 
 int ipc_set_device(const struct wgdevice *conf);
+
+/**
+ * Fetch wireguard device configuration
+ *
+ * Fetch wireguard device configuration from kernel through Netlink socket (or through
+ * different IPC methods from the userspace daemon process)
+ *
+ * @param interface - the interface name
+ * @param conf - the output configuration pointer pointing to an allocated memory
+ *               block which should be freed later by free_conf()
+ * @return 0 on success, negetive on errors. This func should never return positive integer.
+ * @see free_conf()
+ */
 int ipc_fetch_conf(struct wgdevice **conf, const char *interface);
+
+/**
+ * Free the memory block allocated by ipc_fetch_conf()
+ *
+ * free_conf() is an alias of free_wgdevice()
+ * @param conf - the pointer that pointing to allocated memory block
+ * @see ipc_fetch_conf()
+ */
+void free_conf(struct wgdevice *conf);
+
 char *ipc_list_devices(void);
 
 #endif

--- a/src/tools/show.c
+++ b/src/tools/show.c
@@ -398,24 +398,25 @@ int show_main(int argc, char *argv[])
 		ret = !!*interfaces;
 		interface = interfaces;
 		for (size_t len = 0; (len = strlen(interface)); interface += len + 1) {
-			struct wgdevice *device = NULL;
+			struct wgdevice *conf = NULL;
 
-			if (ipc_get_device(&device, interface) < 0) {
+			if (ipc_fetch_conf(&conf, interface) < 0) {
 				fprintf(stderr, "Unable to access interface %s: %s\n", interface, strerror(errno));
 				continue;
 			}
 			if (argc == 3) {
-				if (!ugly_print(device, argv[2], true)) {
+				if (!ugly_print(conf, argv[2], true)) {
 					ret = 1;
-					free_wgdevice(device);
+					free_wgdevice(conf);
 					break;
 				}
 			} else {
-				pretty_print(device);
-				if (strlen(interface + len + 1))
+				pretty_print(conf);
+				if (strlen(interface + len + 1)) {
 					printf("\n");
+				}
 			}
-			free_wgdevice(device);
+			free_wgdevice(conf);
 			ret = 0;
 		}
 		free(interfaces);
@@ -432,24 +433,27 @@ int show_main(int argc, char *argv[])
 			return 1;
 		}
 		interface = interfaces;
-		for (size_t len = 0; (len = strlen(interface)); interface += len + 1)
+		for (size_t len = 0; (len = strlen(interface)); interface += len + 1) {
 			printf("%s%c", interface, strlen(interface + len + 1) ? ' ' : '\n');
+		}
 		free(interfaces);
-	} else if (argc == 2 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help") || !strcmp(argv[1], "help")))
+	} else if (argc == 2 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help") || !strcmp(argv[1], "help"))) {
 		show_usage();
-	else {
-		struct wgdevice *device = NULL;
+	} else {
+		struct wgdevice *conf = NULL;
 
-		if (ipc_get_device(&device, argv[1]) < 0) {
+		if (ipc_fetch_conf(&conf, argv[1]) < 0) {
 			perror("Unable to access interface");
 			return 1;
 		}
 		if (argc == 3) {
-			if (!ugly_print(device, argv[2], false))
+			if (!ugly_print(conf, argv[2], false)) {
 				ret = 1;
-		} else
-			pretty_print(device);
-		free_wgdevice(device);
+			}
+		} else {
+			pretty_print(conf);
+		}
+		free_wgdevice(conf);
 	}
 	return ret;
 }

--- a/src/tools/show.c
+++ b/src/tools/show.c
@@ -407,7 +407,7 @@ int show_main(int argc, char *argv[])
 			if (argc == 3) {
 				if (!ugly_print(conf, argv[2], true)) {
 					ret = 1;
-					free_wgdevice(conf);
+					free_conf(conf);
 					break;
 				}
 			} else {
@@ -416,7 +416,7 @@ int show_main(int argc, char *argv[])
 					printf("\n");
 				}
 			}
-			free_wgdevice(conf);
+			free_conf(conf);
 			ret = 0;
 		}
 		free(interfaces);
@@ -453,7 +453,7 @@ int show_main(int argc, char *argv[])
 		} else {
 			pretty_print(conf);
 		}
-		free_wgdevice(conf);
+		free_conf(conf);
 	}
 	return ret;
 }

--- a/src/tools/showconf.c
+++ b/src/tools/showconf.c
@@ -110,6 +110,6 @@ int showconf_main(int argc, char *argv[])
 	ret = 0;
 
 cleanup:
-	free_wgdevice(conf);
+	free_conf(conf);
 	return ret;
 }


### PR DESCRIPTION
Hi dear developers of WireGuard!

Recently, I've been reading the source code of WireGuard. The function name like ipc_get_device() looks to be a little bit misleading. To make the code more readable for new developers, here are some suggestions:

* Rename `ipc_get_device(&dev)` to `ipc_fetch_conf(&conf)` because it only fetches the runtime configuations rather than a device instance or device handler.
* Funtion prototype ipc_set_device(struct wgdevice *dev) is changed to ipc_set_device(const struct wgdevice *newconf).

Change the following IPC function names and parameters which used to be confusing:
```
- ipc_set_device(dev)                  => ipc_set_device(newconf)
- ipc_get_device(dev, interface)       => ipc_fetch_conf(conf, interface)
- kernel_set_device(dev)               => kernel_set_device(newconf)
- kernel_get_device(device, interface) => kernel_fetch_conf(conf, interface)
- userspace_set_device(dev)            => userspace_set_device(newconf)
- userspace_get_device(out, interface) => userspace_fetch_conf(out, interface)
```

Renamed local variable/parameter symbols:
* In showconf_main(), show_main():
  device => conf
* In ipc_fetch_conf(), kernel_fetch_conf(), userspace_fetch_conf():
  dev => conf
* In ipc_set_device(), kernel_set_device(), userspace_set_device():
  dev => newconf

Note:
A lot of braces are added to the if-else code blocks to keep ourselves from making unexpected mistakes in the future.

Changed function prototypes:
- `int ipc_set_device(struct wgdevice *)` => `int ipc_set_device(const struct wgdevice *newconf)`
- `int kernel_set_device(struct wgdevice *)` => `int kernel_set_device(const struct wgdevice *newconf)`
- `int userspace_set_device(struct wgdevice *)` => `int userspace_set_device(const struct wgdevice *newconf)`